### PR TITLE
Make referer optional as it may not always be available

### DIFF
--- a/src/FINDOLOGIC/Api/Requests/SearchNavigation/SearchNavigationRequest.php
+++ b/src/FINDOLOGIC/Api/Requests/SearchNavigation/SearchNavigationRequest.php
@@ -16,7 +16,6 @@ abstract class SearchNavigationRequest extends Request
     {
         $this->addRequiredParams([
             QueryParameter::USER_IP,
-            QueryParameter::REFERER,
             QueryParameter::REVISION,
         ]);
     }
@@ -42,7 +41,7 @@ abstract class SearchNavigationRequest extends Request
     }
 
     /**
-     * Sets the referer param. It is used to determine on which page a search was fired. Required.
+     * Sets the referer param. It is used to determine on which page a search was fired.
      *
      * @param $value string
      * @see https://docs.findologic.com/doku.php?id=integration_documentation:request#required_parameters

--- a/tests/FINDOLOGIC/Api/Tests/Requests/SearchNavigation/SearchNavigationRequestTest.php
+++ b/tests/FINDOLOGIC/Api/Tests/Requests/SearchNavigation/SearchNavigationRequestTest.php
@@ -44,7 +44,6 @@ class SearchNavigationRequestTest extends TestBase
             'config' => [[
                 'shopurl' => 'blubbergurken.io',
                 'userip' => '127.0.0.1',
-                'referer' => 'https://blubbergurken.io/blubbergurken-sale/',
                 'revision' => '1.0.0',
             ]]
         ];
@@ -116,14 +115,6 @@ class SearchNavigationRequestTest extends TestBase
         }
 
         $navigationRequest->setUserIp('127.0.0.1');
-        try {
-            $client->send($navigationRequest);
-            $this->fail('An exception was expected to happen if the referer param is not set.');
-        } catch (ParamNotSetException $e) {
-            $this->assertEquals('Required param referer is not set.', $e->getMessage());
-        }
-
-        $navigationRequest->setReferer('https://blubbergurken.io/blubbergurken-sale/');
         try {
             $client->send($navigationRequest);
             $this->fail('An exception was expected to happen if the revision param is not set.');


### PR DESCRIPTION
Example:

1. User is on page example.com and fires a search. Referrer is `https://example.com?query=blub`.
2. The User now manually changes the URL to be `https://example.com?query=blubbergurken`.
3. This causes the page to not have any referrer, which furthermore results in an `InvalidParamException`, because the `referer` parameter is required.