### PR TITLE
Fix issue with multiple attributes

### DIFF
--- a/src/Requests/Request.php
+++ b/src/Requests/Request.php
@@ -277,6 +277,20 @@ abstract class Request
         if (!isset($params[QueryParameter::SERVICE_ID])) {
             $params['shopkey'] = $config->getServiceId();
         }
+
+        if (isset($params[QueryParameter::ATTRIB])) {
+            foreach ($params[QueryParameter::ATTRIB] as $key => $values) {
+                if (is_string(array_values($values)[0])) {
+                    continue; // Nothing to do for single select filters.
+                }
+
+                // Multiselect filters are merged with array_merge_recursive, which causes them to be in an array
+                // without a key associated to them. This makes the values appear to be one level too low. We fix
+                // this by manually moving them to the correct level.
+                $params[QueryParameter::ATTRIB][$key] = array_values($values)[0];
+            }
+        }
+
         $queryParams = http_build_query($params);
 
         $apiUrl = sprintf($config->getApiUrl(), $shopUrl, $this->getEndpoint());

--- a/tests/Tests/Requests/SearchNavigation/SearchNavigationRequestTest.php
+++ b/tests/Tests/Requests/SearchNavigation/SearchNavigationRequestTest.php
@@ -794,4 +794,21 @@ class SearchNavigationRequestTest extends TestBase
         $uri = $searchRequest->buildRequestUrl($this->config);
         $this->assertEquals($expectedUri, $uri);
     }
+
+    public function testAttributesAreNotMergedWhenNotNeeded()
+    {
+        $searchRequest = new SearchRequest();
+
+        $searchRequest
+            ->setShopUrl('blubbergurken.io')
+            ->addAttribute('someFilter1', 'someValue')
+            ->addAttribute('someFilter2', 'someOtherValue');
+
+        $expectedUri = 'https://service.findologic.com/ps/blubbergurken.io/index.php?shopurl=blubbergurken.io&';
+        $expectedUri .= 'attrib%5BsomeFilter1%5D%5B%5D=someValue&attrib%5BsomeFilter2%5D%5B%5D=someOtherValue';
+        $expectedUri .= '&shopkey=ABCDABCDABCDABCDABCDABCDABCDABCD';
+
+        $uri = $searchRequest->buildRequestUrl($this->config);
+        $this->assertEquals($expectedUri, $uri);
+    }
 }

--- a/tests/Tests/Requests/SearchNavigation/SearchNavigationRequestTest.php
+++ b/tests/Tests/Requests/SearchNavigation/SearchNavigationRequestTest.php
@@ -777,4 +777,21 @@ class SearchNavigationRequestTest extends TestBase
         $this->assertArrayHasKey($expectedParam, $params);
         $this->assertEquals($expectedGroups, $params[$expectedParam]);
     }
+
+    public function testAttributesAreMergedTogetherProperly()
+    {
+        $searchRequest = new SearchRequest();
+
+        $searchRequest
+            ->setShopUrl('blubbergurken.io')
+            ->addAttribute('someFilter', 'someValue')
+            ->addAttribute('someFilter', 'someOtherValue');
+
+        $expectedUri = 'https://service.findologic.com/ps/blubbergurken.io/index.php?shopurl=blubbergurken.io&';
+        $expectedUri .= 'attrib%5BsomeFilter%5D%5B0%5D=someValue&attrib%5BsomeFilter%5D%5B1%5D=someOtherValue';
+        $expectedUri .= '&shopkey=ABCDABCDABCDABCDABCDABCDABCDABCD';
+
+        $uri = $searchRequest->buildRequestUrl($this->config);
+        $this->assertEquals($expectedUri, $uri);
+    }
 }


### PR DESCRIPTION
Adding multiple attributes with the same key, will result in the array being added one level too much:

```php
$searchRequest
    ->addAttribute('length', '12 cm')
    ->addAttribute('length', '15 cm');

// Request URI will be https://service.findologic.com/ps/www.example.com/index.php?attrib[length][0][0]=12 cm&attrib[length][0][1]=15 cm
```

This fix resolves that issue to build the correct, expected URI.