### PR TITLE
Use findologic/guzzle instead of guzzle/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "findologic/xml-response-schema": "^2.1",
-        "findologic/guzzle": "dev-master"
+        "findologic/guzzle": "^6.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^6.5 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
     },
     "require": {
         "php": ">=5.6",
-        "guzzlehttp/guzzle": "^6.3",
         "vlucas/valitron": "^1.4",
         "ext-SimpleXML": "*",
         "ext-json": "*",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "findologic/xml-response-schema": "^2.1"
+        "findologic/xml-response-schema": "^2.1",
+        "findologic/guzzle": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^6.5 || ^7.0",
@@ -61,5 +61,11 @@
         "test": [
             "phpunit --configuration phpunit.xml --coverage-text --coverage-clover=coverage.xml"
         ]
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:findologic/guzzle.git"
+        }
+    ]
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,7 @@ use FINDOLOGIC\Api\Requests\AlivetestRequest;
 use FINDOLOGIC\Api\Requests\Request;
 use FINDOLOGIC\Api\Requests\SearchNavigation\SearchNavigationRequest;
 use FINDOLOGIC\Api\Responses\Response;
-use GuzzleHttp\Exception\GuzzleException;
+use FINDOLOGIC\GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 
 class Client

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,7 +4,7 @@ namespace FINDOLOGIC\Api;
 
 use FINDOLOGIC\Api\Exceptions\ConfigException;
 use FINDOLOGIC\Api\Validators\ConfigValidator;
-use GuzzleHttp\Client;
+use FINDOLOGIC\GuzzleHttp\Client;
 
 class Config
 {

--- a/tests/Tests/ClientTest.php
+++ b/tests/Tests/ClientTest.php
@@ -11,7 +11,7 @@ use FINDOLOGIC\Api\Requests\SearchNavigation\SearchRequest;
 use FINDOLOGIC\Api\Responses\Autocomplete\SuggestResponse;
 use FINDOLOGIC\Api\Responses\Html\GenericHtmlResponse;
 use FINDOLOGIC\Api\Responses\Xml21\Xml21Response;
-use GuzzleHttp\Exception\RequestException;
+use FINDOLOGIC\GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use InvalidArgumentException;
 

--- a/tests/Tests/ConfigTest.php
+++ b/tests/Tests/ConfigTest.php
@@ -5,7 +5,7 @@ namespace FINDOLOGIC\Api\Tests;
 use Exception;
 use FINDOLOGIC\Api\Config;
 use FINDOLOGIC\Api\Exceptions\ConfigException;
-use GuzzleHttp\Client;
+use FINDOLOGIC\GuzzleHttp\Client;
 use TypeError;
 
 class ConfigTest extends TestBase

--- a/tests/Tests/TestBase.php
+++ b/tests/Tests/TestBase.php
@@ -2,7 +2,7 @@
 
 namespace FINDOLOGIC\Api\Tests;
 
-use GuzzleHttp\Client;
+use FINDOLOGIC\GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
* Having guzzle installed in your project will cause issues when using FINDOLOGIC-API, since we require a different version of guzzle.
* To prevent this from happening we use our own guzzle version. This should resolve namespace and version conflicts.